### PR TITLE
Refactor Service Bus config and update worker setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI for SapAct
 
-on: 
+on:
   workflow_dispatch:
 
   pull_request:

--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -76,8 +76,7 @@ jobs:
       applicationFolder: ${{ inputs.applicationFolder }}
 
   app_deployment_test:
-    if: false
-    needs: [app_package, app_integration_tests_dev]
+    needs: [app_package] #, app_integration_tests_dev
     uses: ./.github/workflows/shared-app-deployment-workflow.yaml
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -76,7 +76,7 @@ jobs:
       applicationFolder: ${{ inputs.applicationFolder }}
 
   app_deployment_test:
-    needs: [app_package] #, app_integration_tests_dev
+    needs: [app_package, app_integration_tests_dev]
     uses: ./.github/workflows/shared-app-deployment-workflow.yaml
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -63,7 +63,6 @@ jobs:
       applicationVersion: ${{ needs.app_package.outputs.applicationVersion }}
 
   app_integration_tests_dev:
-    if: false
     needs: app_deployment_dev
     uses: ./.github/workflows/shared-app-integration-tests-workflow.yaml
     secrets:
@@ -77,6 +76,7 @@ jobs:
       applicationFolder: ${{ inputs.applicationFolder }}
 
   app_deployment_test:
+    if: false
     needs: [app_package, app_integration_tests_dev]
     uses: ./.github/workflows/shared-app-deployment-workflow.yaml
     secrets:

--- a/.github/workflows/shared-app-ci-workflow.yaml
+++ b/.github/workflows/shared-app-ci-workflow.yaml
@@ -1,4 +1,4 @@
-sname: Shared Application CI Workflow
+name: Shared Application CI Workflow
 
 on:
   workflow_call:

--- a/.github/workflows/shared-app-integration-tests-workflow.yaml
+++ b/.github/workflows/shared-app-integration-tests-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
         with:
-          path: mammon     
+          path: sapact
 
       - name: gh-app-install token
         id: gh-app
@@ -50,14 +50,6 @@ jobs:
         with:
           path: devops-azure
           repository: Uniphar/devops-azure
-          token: ${{ steps.gh-app.outputs.token }}
-
-      - name: checkout cost centre definition repo
-        uses: actions/checkout@v3
-        with:
-          path: costcentre-definitions
-          repository: Uniphar/costcentre-definitions
-          ref: main
           token: ${{ steps.gh-app.outputs.token }}
 
       - name: azure login
@@ -78,7 +70,7 @@ jobs:
 
               $AzureKeyVaultName = Resolve-UniResourceName 'keyvault' "$p_devopsDomain-app" -Environment '${{ inputs.environment }}'
 
-              echo "MAMMON_CONFIG_KEYVAULT_URL=https://$AzureKeyVaultName.vault.azure.net" >> $env:GITHUB_ENV
+              echo "SAPACT_CONFIGURATION_URL=https://$AzureKeyVaultName.vault.azure.net" >> $env:GITHUB_ENV
             }
             catch {
               Write-Error $_
@@ -86,5 +78,5 @@ jobs:
             }
 
       - name: run integration tests
-        working-directory: ./mammon/src/${{ inputs.applicationFolder }}.Tests
-        run: dotnet test --filter TestCategory=IntegrationTest --logger "console;verbosity=normal"
+        working-directory: ./sapact/src/${{ inputs.applicationFolder }}.Tests
+        run: dotnet test --filter TestCategory=Integration --logger "console;verbosity=normal"

--- a/devops/Initialize-SapAct.ps1
+++ b/devops/Initialize-SapAct.ps1
@@ -33,7 +33,9 @@ Initializes SapAct in the dev environment.
     $githubActionsDevIdentityObjectId = Get-AzADServicePrincipal -DisplayName $adapp_GithubActionsDev | Select-Object -ExpandProperty Id
     $devopsAppKeyVault = Resolve-UniResourceName 'keyvault' "$p_devopsDomain-app" -Dev:$Dev -Environment $Environment
     $dawnServiceBusName = Resolve-UniResourceName 'service-bus' $p_dawnDomain -Environment $Environment
+    $devopsServiceBusName = Resolve-UniResourceName 'service-bus' $p_devopsDomain -Environment $Environment
     $dceEndpointName = Resolve-UniResourceName 'monitor-dce' $p_sapactProjectName -Environment $Environment
+    $devopsStorageAccountName = Resolve-UniResourceName 'storage' $p_devopsDomain -Dev:$Dev -Environment $Environment
     $logAnalyticsWorkspace = Resolve-UniMainLogAnalytics $Environment
 
     $logAnalyticsDef = @{
@@ -70,9 +72,11 @@ Initializes SapAct in the dev environment.
                                       -adxClusterName $adxClusterName `
                                       -adxDatabase $adxDatabase `
                                       -appKeyVaultName $devopsAppKeyVault `
-                                      -sbNamespace $dawnServiceBusName `
+                                      -dawnSBNamespace $dawnServiceBusName `
+                                      -devopsSBNamespace $devopsServiceBusName `
                                       -dceName $dceEndpointName `
                                       -logAnalytics $logAnalyticsDef `
+                                      -storageAccountName $devopsStorageAccountName `
                                       -Verbose:($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent -eq $true)
     }
     else {
@@ -82,8 +86,11 @@ Initializes SapAct in the dev environment.
                                                      -adxClusterName $adxClusterName `
                                                      -adxDatabase $adxDatabase `
                                                      -appKeyVaultName $devopsAppKeyVault `
-                                                     -sbNamespace $dawnServiceBusName `
+                                                     -dawnSBNamespace $dawnServiceBusName `
+                                                     -devopsSBNamespace $devopsServiceBusName `
                                                      -dceName $dceEndpointName `
+                                                     -logAnalytics $logAnalyticsDef `
+                                                     -storageAccountName $devopsStorageAccountName `
                                                      -Verbose:($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent -eq $true)
 
         if ($TestResult) {

--- a/devops/sapact.project.bicep
+++ b/devops/sapact.project.bicep
@@ -1,15 +1,21 @@
 param adxClusterName string
 param adxDatabase object
 param appKeyVaultName string
-param sbNamespace string
+param dawnSBNamespace string
+param devopsSBNamespace string
 param dceName string
 param logAnalytics object
+param storageAccountName string
 
 param location string = resourceGroup().location
 
 resource adxCluster 'Microsoft.Kusto/clusters@2023-08-15' existing = {
   name: adxClusterName
 
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: storageAccountName
 }
 
 resource database 'Microsoft.Kusto/clusters/databases@2023-08-15' = {
@@ -45,19 +51,43 @@ resource DevopsAppKeyVault 'Microsoft.KeyVault/vaults@2022-07-01'  existing = {
   name: appKeyVaultName
 }
 
-resource SBConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
-  name: 'SapAct--ServiceBus--ConnectionString'
+resource SB0ConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: 'SapAct--ServiceBus--Topic--0--ConnectionString'
   parent: DevopsAppKeyVault
   properties: {
-    value: '${sbNamespace}.servicebus.windows.net'
+    value: '${dawnSBNamespace}.servicebus.windows.net'
   }
 }
 
-resource SBTopicNameSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
-  name: 'SapAct--ServiceBus--TopicName'
+resource SB0TopicNameSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: 'SapAct--ServiceBus--Topic--0--Name'
   parent: DevopsAppKeyVault
   properties: {
     value: 'sap-events'
+  }
+}
+
+resource SB1ConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: 'SapAct--ServiceBus--Topic--1--ConnectionString'
+  parent: DevopsAppKeyVault
+  properties: {
+    value: '${devopsSBNamespace}.servicebus.windows.net'
+  }
+}
+
+resource SB1TopicNameSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: 'SapAct--ServiceBus--Topic--1--Name'
+  parent: DevopsAppKeyVault
+  properties: {
+    value: 'sapactinttests'
+  }
+}
+
+resource StorageAccountConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: 'SapAct--LockService--BlobConnectionString'
+  parent: DevopsAppKeyVault
+  properties: {
+    value: storageAccount.properties.primaryEndpoints.blob
   }
 }
 

--- a/src/SapAct.Tests/DeveloperTests.cs
+++ b/src/SapAct.Tests/DeveloperTests.cs
@@ -23,11 +23,11 @@ public class DeveloperTests
 			.AddAzureKeyVault(new(azureKeyVaultName), credential)
 			.Build();
 
-		var sbConnectionString = _config[Consts.ServiceBusConnectionStringConfigKey];
+		var intTestTopicConfig = _config.GetIntTestsServiceBusConfig();
 
-		var sbClient = new ServiceBusClient(sbConnectionString, credential);
+		var sbClient = new ServiceBusClient(intTestTopicConfig.ConnectionString, credential);
 
-		_messageBusSender = sbClient.CreateSender(_config[Consts.ServiceBusTopicNameConfigKey]);
+		_messageBusSender = sbClient.CreateSender(intTestTopicConfig.TopicName);
 	}
 
 	[TestMethod]

--- a/src/SapAct.Tests/GlobalUsings.cs
+++ b/src/SapAct.Tests/GlobalUsings.cs
@@ -11,7 +11,7 @@ global using Kusto.Data.Exceptions;
 global using Kusto.Data.Net.Client;
 global using Microsoft.Extensions.Configuration;
 global using SapAct.Extensions;
+global using SapAct.Models;
 global using SapAct.Services;
-global using System.Globalization;
 global using System.Text;
 global using System.Text.Json;

--- a/src/SapAct.Tests/IConfigurationTestExtensions.cs
+++ b/src/SapAct.Tests/IConfigurationTestExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace SapAct.Tests;
+
+public static class IConfigurationTestExtensions
+{
+	public static ServiceBusTopicConfiguration GetIntTestsServiceBusConfig(this IConfiguration configuration)
+	{
+		var sbTopicConfigs = configuration.GetServiceBusTopicConfiguration();
+		return sbTopicConfigs.First(c => c.TopicName.Contains("inttest", StringComparison.OrdinalIgnoreCase));
+	}
+}

--- a/src/SapAct.Tests/IntegrationTests.cs
+++ b/src/SapAct.Tests/IntegrationTests.cs
@@ -34,11 +34,12 @@ public class IntegrationTests
 			.AddAzureKeyVault(new(azureKeyVaultName), credential)
 			.Build();
 
-		var sbConnectionString = _config[Consts.ServiceBusConnectionStringConfigKey];
+		var intTestTopicConfig = _config.GetIntTestsServiceBusConfig();
 
-		var sbClient = new ServiceBusClient(sbConnectionString, credential);
+		var sbClient = new ServiceBusClient(intTestTopicConfig.ConnectionString, credential);
 
-		_messageBusSender = sbClient.CreateSender(_config[Consts.ServiceBusTopicNameConfigKey]);
+		_messageBusSender = sbClient.CreateSender(intTestTopicConfig.TopicName);
+
 		_blobServiceClient = new(new Uri(_config[Consts.LockServiceBlobConnectionStringConfigKey]), credential);
 		_blobContainerClient = _blobServiceClient.GetBlobContainerClient(_config.GetLockServiceBlobContainerNameOrDefault());
 

--- a/src/SapAct/Consts.cs
+++ b/src/SapAct/Consts.cs
@@ -4,8 +4,10 @@ public static class Consts
 {
 	public const string KEYVAULT_CONFIG_URL = "SAPACT_CONFIGURATION_URL";
 
-	public const string ServiceBusConnectionStringConfigKey = "SapAct:ServiceBus:ConnectionString";
-	public const string ServiceBusTopicNameConfigKey = "SapAct:ServiceBus:TopicName";
+	public const string ServiceBusConfigurationSectionName = "SapAct:ServiceBus:Topic";
+	public const string ServiceBusConnectionStringConfigKey = "ConnectionString";
+	public const string ServiceBusTopicNameConfigKey = "Name";
+
 	public const string ServiceBusTopicSubscriptionNamePrefixConfigKey = "SapAct:ServiceBus:TopicSubscriptionNamePrefix";
 
 	public const string LogAnalyticsSubscriptionIdConfigKey = "SapAct:LogAnalytics:SubscriptionId";

--- a/src/SapAct/Extensions/HostApplicationBuilderExtension.cs
+++ b/src/SapAct/Extensions/HostApplicationBuilderExtension.cs
@@ -1,0 +1,36 @@
+﻿namespace SapAct.Extensions;
+
+public static class HostApplicationBuilderExtension
+{
+	public static async Task SetupWorkersAsync(this HostApplicationBuilder builder)
+	{
+		var serviceBusTopics = builder.Configuration.GetServiceBusTopicConfiguration();
+
+		foreach (var serviceBusTopic in serviceBusTopics)
+		{
+			string name = $"{serviceBusTopic.ConnectionString}-{serviceBusTopic.TopicName}";
+
+			builder.Services.AddAzureClients((clientBuilder) =>
+			{
+				clientBuilder
+					.AddServiceBusAdministrationClientWithNamespace(serviceBusTopic.ConnectionString!)
+					.WithName(name);
+
+				clientBuilder
+					.AddServiceBusClientWithNamespace(serviceBusTopic.ConnectionString!)
+					.WithName(name);
+			});
+
+			//see https://github.com/dotnet/runtime/issues/38751
+			builder.Services.AddSingleton<IHostedService, ADXWorker>((sp) =>
+			{
+				return new ADXWorker(name, serviceBusTopic, sp.GetRequiredService<IAzureClientFactory<ServiceBusClient>>(), sp.GetRequiredService<IAzureClientFactory<ServiceBusAdministrationClient>>(), sp.GetRequiredService<ADXService>(), sp.GetRequiredService<ILogger<ADXWorker>>(), builder.Configuration);
+			});
+
+			builder.Services.AddSingleton<IHostedService, LogAnalyticsWorker>((sp) =>
+			{
+				return new LogAnalyticsWorker(name, serviceBusTopic, sp.GetRequiredService<IAzureClientFactory<ServiceBusClient>>(), sp.GetRequiredService<IAzureClientFactory<ServiceBusAdministrationClient>>(), sp.GetRequiredService<LogAnalyticsService>(), sp.GetRequiredService<ILogger<LogAnalyticsWorker>>(), builder.Configuration);
+			});
+		}
+	}
+}

--- a/src/SapAct/Extensions/HostApplicationBuilderExtension.cs
+++ b/src/SapAct/Extensions/HostApplicationBuilderExtension.cs
@@ -2,7 +2,7 @@
 
 public static class HostApplicationBuilderExtension
 {
-	public static async Task SetupWorkersAsync(this HostApplicationBuilder builder)
+	public static void SetupWorkers(this HostApplicationBuilder builder)
 	{
 		var serviceBusTopics = builder.Configuration.GetServiceBusTopicConfiguration();
 

--- a/src/SapAct/Extensions/IConfigurationExtensions.cs
+++ b/src/SapAct/Extensions/IConfigurationExtensions.cs
@@ -7,10 +7,19 @@ public static class IConfigurationExtensions
 		new ConfigurationValidator().Validate(configuration);
 	}
 
-	public static string? GetServiceBusConnectionString(this IConfiguration configuration) => configuration[Consts.ServiceBusConnectionStringConfigKey];
-
-	public static string? GetServiceBusTopicName(this IConfiguration configuration) => configuration[Consts.ServiceBusTopicNameConfigKey];
-
+	public static IEnumerable<ServiceBusTopicConfiguration> GetServiceBusTopicConfiguration(this IConfiguration configuration)
+	{
+		var topics = new List<ServiceBusTopicConfiguration>();
+		foreach (var section in configuration.GetSection(Consts.ServiceBusConfigurationSectionName).GetChildren())
+		{
+			topics.Add(new ServiceBusTopicConfiguration
+			{
+				ConnectionString = section[Consts.ServiceBusConnectionStringConfigKey]!,
+				TopicName = section[Consts.ServiceBusTopicNameConfigKey]!
+			});
+		}
+		return topics;
+	}
 	public static string? GetLogAnalyticsEndpointName(this IConfiguration configuration) => configuration[Consts.LogAnalyticsEndpointNameConfigKey];
 
 	public static string GetTopicSubscriptionNameOrDefault<T>(this IConfiguration configuration) => configuration[$"{Consts.ServiceBusTopicSubscriptionNamePrefixConfigKey}{typeof(T).Name}"] ?? $"SapAct{typeof(T).Name}";

--- a/src/SapAct/Models/ServiceBusTopicConfiguration.cs
+++ b/src/SapAct/Models/ServiceBusTopicConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace SapAct.Models;
+
+public record ServiceBusTopicConfiguration
+{
+	public required string ConnectionString;
+	public required string TopicName;
+}

--- a/src/SapAct/Program.cs
+++ b/src/SapAct/Program.cs
@@ -24,6 +24,8 @@ builder.Services.AddAzureClients((clientBuilder) =>
 {
 	clientBuilder.AddLogsIngestionClient(new Uri(builder.Configuration.GetLogAnalyticsIngestionUrl()!));
 	clientBuilder.AddBlobServiceClient(new Uri(builder.Configuration.GetLockServiceBlobConnectionString()!));
+
+	clientBuilder.UseCredential(credential);
 });
 
 var KustoConnectionStringBuilder = new KustoConnectionStringBuilder(builder.Configuration.GetADXClusterHostUrl(), builder.Configuration.GetADXClusterDBNameOrDefault())

--- a/src/SapAct/Program.cs
+++ b/src/SapAct/Program.cs
@@ -18,7 +18,7 @@ builder.Configuration.AddAzureKeyVault(new(configKVUrl), credential);
 
 builder.Configuration.CheckConfiguration();
 
-await builder.SetupWorkersAsync();
+builder.SetupWorkers();
 
 builder.Services.AddAzureClients((clientBuilder) => 
 {

--- a/src/SapAct/Services/ResourceInitializerService.cs
+++ b/src/SapAct/Services/ResourceInitializerService.cs
@@ -1,14 +1,9 @@
 ﻿namespace SapAct.Services;
 
-public class ResourceInitializerService(BlobServiceClient blobServiceClient, ServiceBusAdministrationClient serviceBusAdministrationClient,  IConfiguration configuration)
+public class ResourceInitializerService(BlobServiceClient blobServiceClient, IConfiguration configuration)
 {
 	public async Task InitializeResourcesAsync()
-	{
-		if (!await serviceBusAdministrationClient.TopicExistsAsync(configuration.GetServiceBusTopicName()))
-		{
-			await serviceBusAdministrationClient.CreateTopicAsync(configuration.GetServiceBusTopicName());
-		}
-		//SB subscriptions created per subscription/worker
+	{		
 		await blobServiceClient.GetBlobContainerClient(configuration.GetLockServiceBlobContainerNameOrDefault()).CreateIfNotExistsAsync();
 	}
 }

--- a/src/SapAct/Workers/ADXWorker.cs
+++ b/src/SapAct/Workers/ADXWorker.cs
@@ -1,6 +1,14 @@
 ﻿namespace SapAct.Workers;
 
-public class ADXWorker(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, ADXService adxService, ILogger<ADXWorker> logger, IConfiguration configuration) : SapActBaseWorker<ADXWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
+public class ADXWorker(
+    string workerName, 
+    ServiceBusTopicConfiguration serviceBusTopicConfiguration, 
+    IAzureClientFactory<ServiceBusClient> sbClientFactory, 
+    IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, 
+    ADXService adxService, 
+    ILogger<ADXWorker> logger, 
+    IConfiguration configuration) 
+        : SapActBaseWorker<ADXWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
 {
     public override async Task IngestMessageAsync(JsonElement item, CancellationToken cancellationToken)
     {

--- a/src/SapAct/Workers/ADXWorker.cs
+++ b/src/SapAct/Workers/ADXWorker.cs
@@ -1,6 +1,6 @@
 ﻿namespace SapAct.Workers;
 
-public class ADXWorker(ServiceBusClient sbClient, ServiceBusAdministrationClient managementClient, ADXService adxService, ILogger<ADXWorker> logger, IConfiguration configuration) : SapActBaseWorker<ADXWorker>(sbClient, managementClient, configuration, logger)
+public class ADXWorker(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, ADXService adxService, ILogger<ADXWorker> logger, IConfiguration configuration) : SapActBaseWorker<ADXWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
 {
     public override async Task IngestMessageAsync(JsonElement item, CancellationToken cancellationToken)
     {

--- a/src/SapAct/Workers/LogAnalyticsWorker.cs
+++ b/src/SapAct/Workers/LogAnalyticsWorker.cs
@@ -1,6 +1,6 @@
 ﻿namespace SapAct.Workers;
 
-public class LogAnalyticsWorker(ServiceBusClient sbClient, ServiceBusAdministrationClient managementClient, LogAnalyticsService logAnalyticsService, ILogger<LogAnalyticsWorker> logger, IConfiguration configuration) : SapActBaseWorker<LogAnalyticsWorker>(sbClient, managementClient, configuration, logger)
+public class LogAnalyticsWorker(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, LogAnalyticsService logAnalyticsService, ILogger<LogAnalyticsWorker> logger, IConfiguration configuration) : SapActBaseWorker<LogAnalyticsWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
 {
     public override async Task IngestMessageAsync(JsonElement item, CancellationToken cancellationToken)
     {

--- a/src/SapAct/Workers/LogAnalyticsWorker.cs
+++ b/src/SapAct/Workers/LogAnalyticsWorker.cs
@@ -1,6 +1,14 @@
 ﻿namespace SapAct.Workers;
 
-public class LogAnalyticsWorker(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, LogAnalyticsService logAnalyticsService, ILogger<LogAnalyticsWorker> logger, IConfiguration configuration) : SapActBaseWorker<LogAnalyticsWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
+public class LogAnalyticsWorker(
+    string workerName, 
+    ServiceBusTopicConfiguration serviceBusTopicConfiguration, 
+    IAzureClientFactory<ServiceBusClient> sbClientFactory, 
+    IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, 
+    LogAnalyticsService logAnalyticsService, 
+    ILogger<LogAnalyticsWorker> logger, 
+    IConfiguration configuration) 
+        : SapActBaseWorker<LogAnalyticsWorker>(workerName, serviceBusTopicConfiguration, sbClientFactory, sbAdminClientFactory, configuration, logger)
 {
     public override async Task IngestMessageAsync(JsonElement item, CancellationToken cancellationToken)
     {

--- a/src/SapAct/Workers/SapActBaseWorker.cs
+++ b/src/SapAct/Workers/SapActBaseWorker.cs
@@ -86,7 +86,7 @@ public abstract class SapActBaseWorker<T>(
 
         JsonDocument jsonDocument = JsonDocument.Parse(Encoding.UTF8.GetString(message.Body));
 
-        for (int x = 0; x < jsonDocument.RootElement.GetArrayLength(); x++) //TODO: this is temporary, array not expected
+		for (int x = 0; x < jsonDocument.RootElement.GetArrayLength(); x++) //TODO: this is temporary, array not expected
         {
             var item = jsonDocument.RootElement[x];
 

--- a/src/SapAct/Workers/SapActBaseWorker.cs
+++ b/src/SapAct/Workers/SapActBaseWorker.cs
@@ -1,23 +1,47 @@
 ﻿namespace SapAct.Workers;
 
-public abstract class SapActBaseWorker<T>(ServiceBusClient sbClient, ServiceBusAdministrationClient managementClient, IConfiguration configuration, ILogger<T> logger) : BackgroundService
+public abstract class SapActBaseWorker<T>(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, IConfiguration configuration, ILogger<T> logger) : BackgroundService
 {
     private ServiceBusReceiver? serviceBusReceiver;
 
-    internal async Task EnsureTopicSubscriptionAsync(string topicName, string subscriptionName, CancellationToken cancellationToken = default)
+    internal async Task EnsureServiceBusResourcesAsync(string topicName, string subscriptionName, CancellationToken cancellationToken = default)
     {
-        if (!await managementClient.SubscriptionExistsAsync(topicName, subscriptionName, cancellationToken))
+		var managementClient = sbAdminClientFactory.CreateClient(workerName);
+
+        if (!await managementClient.TopicExistsAsync(topicName, cancellationToken))
+		{
+            try
+            {
+                await managementClient.CreateTopicAsync(topicName, cancellationToken);
+            }
+            catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+			{
+                //this may happen as topic is shared by worker subscriptions so race condition is possible
+				//do nothing, topic already exists
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "Error creating topic");
+				throw;
+			}
+		}
+
+		if (!await managementClient.SubscriptionExistsAsync(topicName, subscriptionName, cancellationToken))
         {
             await managementClient.CreateSubscriptionAsync(topicName, subscriptionName, cancellationToken);
-        }
+		}
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var topicName = configuration.GetServiceBusTopicName()!;
+        var topicName = serviceBusTopicConfiguration.TopicName;
         var subscriptionName = configuration.GetTopicSubscriptionNameOrDefault<T>();
-        await EnsureTopicSubscriptionAsync(topicName, subscriptionName, cancellationToken);
-        serviceBusReceiver = sbClient.CreateReceiver(configuration[Consts.ServiceBusTopicNameConfigKey], subscriptionName, new ServiceBusReceiverOptions()
+
+        await EnsureServiceBusResourcesAsync(topicName, subscriptionName, cancellationToken);
+
+        var sbClient = sbClientFactory.CreateClient(workerName);
+
+		serviceBusReceiver = sbClient.CreateReceiver(topicName, subscriptionName, new ServiceBusReceiverOptions()
         {
             ReceiveMode = ServiceBusReceiveMode.PeekLock
 #if (DEBUG)

--- a/src/SapAct/Workers/SapActBaseWorker.cs
+++ b/src/SapAct/Workers/SapActBaseWorker.cs
@@ -1,6 +1,13 @@
 ﻿namespace SapAct.Workers;
 
-public abstract class SapActBaseWorker<T>(string workerName, ServiceBusTopicConfiguration serviceBusTopicConfiguration, IAzureClientFactory<ServiceBusClient> sbClientFactory, IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, IConfiguration configuration, ILogger<T> logger) : BackgroundService
+public abstract class SapActBaseWorker<T>(
+    string workerName, 
+    ServiceBusTopicConfiguration serviceBusTopicConfiguration, 
+    IAzureClientFactory<ServiceBusClient> sbClientFactory, 
+    IAzureClientFactory<ServiceBusAdministrationClient> sbAdminClientFactory, 
+    IConfiguration configuration, 
+    ILogger<T> logger) 
+        : BackgroundService
 {
     private ServiceBusReceiver? serviceBusReceiver;
 


### PR DESCRIPTION
Updated `DeveloperTests` and `IntegrationTests` to use `GetIntTestsServiceBusConfig` for Service Bus configuration. Modified `GlobalUsings.cs` to include `SapAct.Models` and remove `System.Globalization`. Consolidated Service Bus config keys in `Consts.cs`. Replaced individual Service Bus config retrieval methods in `IConfigurationExtensions.cs` with a method for `ServiceBusTopicConfiguration` collection. Enhanced `ConfigurationValidator.cs` for new Service Bus config structure.

In `Program.cs`, added `ResourceInitializerService`, used `SetupWorkersAsync` for Service Bus setup, and updated Kusto client registration. Fixed typo in `LogAnalyticsService.cs`. Refined `ResourceInitializerService.cs` to focus on blob service initialization. Updated `ADXWorker.cs`, `LogAnalyticsWorker.cs`, and `SapActBaseWorker.cs` to use new constructors and ensure Service Bus resources.

Added `IConfigurationTestExtensions.cs` for integration test Service Bus config retrieval. Introduced `HostApplicationBuilderExtension.cs` for `SetupWorkersAsync` method. Added `ServiceBusTopicConfiguration.cs` to define Service Bus topic configuration.

[AB#39458](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/39458)