### PR TITLE
Filter out Delta events and int tests

### DIFF
--- a/src/SapAct.Tests/GlobalUsings.cs
+++ b/src/SapAct.Tests/GlobalUsings.cs
@@ -1,6 +1,7 @@
 ﻿global using Azure;
 global using Azure.Identity;
 global using Azure.Messaging.ServiceBus;
+global using Azure.Messaging.ServiceBus.Administration;
 global using Azure.Monitor.Query;
 global using Azure.Monitor.Query.Models;
 global using Azure.Storage.Blobs;
@@ -11,13 +12,12 @@ global using Kusto.Data.Exceptions;
 global using Kusto.Data.Net.Client;
 global using Microsoft.Data.SqlClient;
 global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
 global using SapAct.Extensions;
 global using SapAct.Models;
 global using SapAct.Services;
 global using SapAct.Tests.Extensions;
+global using SapAct.Workers;
+global using System.Data;
 global using System.Text;
 global using System.Text.Json;
-global using Microsoft.Extensions.Logging;
-global using Moq;
 

--- a/src/SapAct.Tests/IntegrationTests.cs
+++ b/src/SapAct.Tests/IntegrationTests.cs
@@ -1,10 +1,4 @@
-﻿using Azure.Messaging.ServiceBus.Administration;
-using Microsoft.Azure.Amqp.Framing;
-using SapAct.Workers;
-using System.Data;
-using System.Threading;
-
-namespace SapAct.Tests;
+﻿namespace SapAct.Tests;
 
 [TestClass, TestCategory("Integration")]
 public class IntegrationTests

--- a/src/SapAct.Tests/IntegrationTests.cs
+++ b/src/SapAct.Tests/IntegrationTests.cs
@@ -71,7 +71,6 @@ public class IntegrationTests
 		//arrange
 		await DropSQLTable("SapActIntTests");
 		await DropSQLTable("SapActIntTests_SchemaTable");
-		await DropSQLTable("SapActIntTests0");
 
 		await DropADXTableAsync();
 
@@ -118,7 +117,6 @@ public class IntegrationTests
 		//arrange
 		await DropSQLTable("SapActIntTests");
 		await DropSQLTable("SapActIntTests_SchemaTable");
-		await DropSQLTable("SapActIntTests0");
 
 		await DropADXTableAsync();
 

--- a/src/SapAct.Tests/PayloadHelper.cs
+++ b/src/SapAct.Tests/PayloadHelper.cs
@@ -4,11 +4,11 @@ public class PayloadHelper
 {
 	public const string ExtendedSchemaColumnName = "extendedSchemaColumn";
 
-	public static string GetPayload(string objectType, string objectKey, string version, bool extendedSchema = false)
+	public static string GetPayload(string objectType, string objectKey, string version, bool extendedSchema = false, bool deltaChangePayload = false)
 	{
 		if (!extendedSchema)
-			return $"[{{\"objectType\":\"{objectType}\",\"objectKey\":\"{objectKey}\", \"dataVersion\":\"{version}\", \"blah\": \"blah\"}}]";
+			return $"[{{\"objectType\":\"{objectType}\",\"objectKey\":\"{objectKey}\", \"dataVersion\":\"{version}\", \"eventType\":\"{(deltaChangePayload ? Consts.DeltaEventType : "Changed")}\", \"blah\": \"blah\"}}]";
 		else
-			return $"[{{\"objectType\":\"{objectType}\",\"objectKey\":\"{objectKey}\", \"dataVersion\":\"{version}\", \"{ExtendedSchemaColumnName}\":\"value\"}}]";
+			return $"[{{\"objectType\":\"{objectType}\",\"objectKey\":\"{objectKey}\", \"dataVersion\":\"{version}\", \"eventType\":\"{(deltaChangePayload ? Consts.DeltaEventType : "Changed" )}\", \"{ExtendedSchemaColumnName}\":\"value\"}}]";
 	}
 }

--- a/src/SapAct/Consts.cs
+++ b/src/SapAct/Consts.cs
@@ -39,4 +39,7 @@ public static class Consts
 	public const string MessageObjectKeyPropertyName = "objectKey";
 	public const string MessageObjectTypePropertyName = "objectType";
 	public const string MessageDataVersionPropertyName = "dataVersion";
+	public const string MessageEventTypePropertyName = "eventType";
+
+	public const string DeltaEventType = "ChangeDelta";
 }

--- a/src/SapAct/Models/MessageRootProperties.cs
+++ b/src/SapAct/Models/MessageRootProperties.cs
@@ -1,6 +1,6 @@
 ﻿namespace SapAct.Models;
 
-public record RootMessageProperties
+public record MessageRootProperties
 {
 	public required string objectKey;
 	public required string objectType;

--- a/src/SapAct/Models/RootMessageProperties.cs
+++ b/src/SapAct/Models/RootMessageProperties.cs
@@ -1,0 +1,9 @@
+﻿namespace SapAct.Models;
+
+public record RootMessageProperties
+{
+	public required string objectKey;
+	public required string objectType;
+	public required string dataVersion;
+	public string? eventType;
+}

--- a/src/SapAct/SapAct.csproj
+++ b/src/SapAct/SapAct.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="*" />
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
+    <PackageReference Include="Azure.Identity" Version="*" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="*" />
     <PackageReference Include="Azure.Monitor.Ingestion" Version="*" />
     <PackageReference Include="Azure.Storage.Blobs" Version="*" />

--- a/src/SapAct/Services/ADXService.cs
+++ b/src/SapAct/Services/ADXService.cs
@@ -5,7 +5,7 @@ public class ADXService (IAzureDataExplorerClient adxClient, ILockService lockSe
 	public async Task IngestMessage(JsonElement payload, CancellationToken cancellationToken)
 	{
 		//get key properties
-		var messageProperties = ExtractKeyMessageProperties(payload);
+		var messageProperties = ExtractMessageRootProperties(payload);
 		if (Consts.DeltaEventType == messageProperties.eventType)
 			return;
 

--- a/src/SapAct/Services/LogAnalyticsService.cs
+++ b/src/SapAct/Services/LogAnalyticsService.cs
@@ -109,53 +109,48 @@ public class LogAnalyticsService(
 	public async Task IngestMessage(JsonElement payload, CancellationToken cancellationToken)
 	{
 		//get key properties
-		ExtractKeyMessageProperties(payload, out var objectKey, out var objectType, out var dataVersion);
+		var messageProperties = ExtractKeyMessageProperties(payload);
+		if (Consts.DeltaEventType == messageProperties.eventType)
+			return;
 
-		if (!string.IsNullOrWhiteSpace(objectKey) && !string.IsNullOrWhiteSpace(objectType) && !string.IsNullOrWhiteSpace(dataVersion))
-		{
-			var schemaCheckResult = await CheckObjectTypeSchemaAsync(objectType, dataVersion, TargetStorageEnum.LogAnalytics);
+		var schemaCheckResult = await CheckObjectTypeSchemaAsync(messageProperties.objectType, messageProperties.dataVersion, TargetStorageEnum.LogAnalytics);
 
-			string dcrId = "";
+		string dcrId = "";
 
-			if (schemaCheckResult == SchemaCheckResultState.Unknown || schemaCheckResult == SchemaCheckResultState.Older)
-			{			
-				bool updateNecessary = true;
-				do
-				{
-					(var lockState, string? leaseId) = await ObtainLockAsync(objectType!, dataVersion!, TargetStorageEnum.LogAnalytics);
-					if (lockState == LockState.LockObtained)
-					{
-						dcrId = await SyncTableSchema(objectType, payload, schemaCheckResult, cancellationToken);
-						UpdateSchema(objectType, dataVersion, dcrId);
-						await ReleaseLockAsync(objectType!, dataVersion!, TargetStorageEnum.LogAnalytics, leaseId!);
-
-						updateNecessary = false;
-					}
-					else if (lockState == LockState.Available)
-					{
-						//schema was updated by another instance but let's check against persistent storage
-						var status = await CheckObjectTypeSchemaAsync(objectType!, dataVersion!, TargetStorageEnum.LogAnalytics);
-						updateNecessary = status != SchemaCheckResultState.Current;
-                        if (!updateNecessary)
-                        {
-                            dcrId = await RefreshDCRIdAsync(objectType, cancellationToken);
-							UpdateSchema(objectType, dataVersion, dcrId);
-						}    
-					}
-				} while (updateNecessary);
-			}
-			else
+		if (schemaCheckResult == SchemaCheckResultState.Unknown || schemaCheckResult == SchemaCheckResultState.Older)
+		{			
+			bool updateNecessary = true;
+			do
 			{
-				dcrId = await RefreshDCRIdAsync(objectType, cancellationToken); //TODO: maybe store as another metadata piece in the blob
-			}			
+				(var lockState, string? leaseId) = await ObtainLockAsync(messageProperties.objectType, messageProperties.dataVersion, TargetStorageEnum.LogAnalytics);
+				if (lockState == LockState.LockObtained)
+				{
+					dcrId = await SyncTableSchema(messageProperties.objectType, payload, schemaCheckResult, cancellationToken);
+					UpdateSchema(messageProperties.objectType, messageProperties.dataVersion, dcrId);
+					await ReleaseLockAsync(messageProperties.objectType, messageProperties.dataVersion, TargetStorageEnum.LogAnalytics, leaseId!);
 
-			//send to log analytics
-			await SinkToLogAnalytics(objectType, dcrId!, payload);
+					updateNecessary = false;
+				}
+				else if (lockState == LockState.Available)
+				{
+					//schema was updated by another instance but let's check against persistent storage
+					var status = await CheckObjectTypeSchemaAsync(messageProperties.objectType, messageProperties.dataVersion, TargetStorageEnum.LogAnalytics);
+					updateNecessary = status != SchemaCheckResultState.Current;
+                    if (!updateNecessary)
+                    {
+                        dcrId = await RefreshDCRIdAsync(messageProperties.objectType, cancellationToken);
+						UpdateSchema(messageProperties.objectType, messageProperties.dataVersion, dcrId);
+					}    
+				}
+			} while (updateNecessary);
 		}
 		else
 		{
-			throw new InvalidOperationException("Invalid message format");
-		}
+			dcrId = await RefreshDCRIdAsync(messageProperties.objectType, cancellationToken); //TODO: maybe store as another metadata piece in the blob
+		}			
+
+		//send to log analytics
+		await SinkToLogAnalytics(messageProperties.objectType, dcrId!, payload);		
 	}
 
 	private async Task<string> RefreshDCRIdAsync(string tableName, CancellationToken cancellationToken)

--- a/src/SapAct/Services/LogAnalyticsService.cs
+++ b/src/SapAct/Services/LogAnalyticsService.cs
@@ -109,7 +109,7 @@ public class LogAnalyticsService(
 	public async Task IngestMessage(JsonElement payload, CancellationToken cancellationToken)
 	{
 		//get key properties
-		var messageProperties = ExtractKeyMessageProperties(payload);
+		var messageProperties = ExtractMessageRootProperties(payload);
 		if (Consts.DeltaEventType == messageProperties.eventType)
 			return;
 

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -9,7 +9,7 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 
 	public async Task IngestMessageAsync(JsonElement payload, CancellationToken cancellationToken = default)
 	{
-		var messageProperties = ExtractKeyMessageProperties(payload);
+		var messageProperties = ExtractMessageRootProperties(payload);
 		if (Consts.DeltaEventType == messageProperties.eventType)
 			return;
 

--- a/src/SapAct/Services/VersionedSchemaBaseService.cs
+++ b/src/SapAct/Services/VersionedSchemaBaseService.cs
@@ -46,11 +46,26 @@ public abstract class VersionedSchemaBaseService(ILockService lockService)
 		return schemaCompareResult;
 	}
 
-	protected static void ExtractKeyMessageProperties(JsonElement payload, out string? objectKey, out string? objectType, out string? dataVersion)
+	protected static RootMessageProperties ExtractKeyMessageProperties(JsonElement payload)
 	{
-		objectKey = payload.GetProperty(Consts.MessageObjectKeyPropertyName).GetString();
-		objectType = payload.GetProperty(Consts.MessageObjectTypePropertyName).GetString();
-		dataVersion = payload.GetProperty(Consts.MessageDataVersionPropertyName).GetString();
+		var objectKey = payload.GetProperty(Consts.MessageObjectKeyPropertyName).GetString();
+		var objectType = payload.GetProperty(Consts.MessageObjectTypePropertyName).GetString();
+		var dataVersion = payload.GetProperty(Consts.MessageDataVersionPropertyName).GetString();
+		
+		var eventTypePropertyExists = payload.TryGetProperty(Consts.MessageEventTypePropertyName, out var eventTypeProperty);
+		var eventType = eventTypePropertyExists ? eventTypeProperty.GetString() : null;
+
+		ArgumentException.ThrowIfNullOrWhiteSpace(objectKey);
+		ArgumentException.ThrowIfNullOrWhiteSpace(objectType);
+		ArgumentException.ThrowIfNullOrWhiteSpace(dataVersion);
+
+		return new RootMessageProperties
+		{
+			objectKey = objectKey,
+			objectType = objectType,
+			dataVersion = dataVersion,
+			eventType = eventType
+		};	
 	}
 
 	protected void UpdateObjectTypeSchema(string objectType, string version)

--- a/src/SapAct/Services/VersionedSchemaBaseService.cs
+++ b/src/SapAct/Services/VersionedSchemaBaseService.cs
@@ -46,7 +46,7 @@ public abstract class VersionedSchemaBaseService(ILockService lockService)
 		return schemaCompareResult;
 	}
 
-	protected static RootMessageProperties ExtractKeyMessageProperties(JsonElement payload)
+	protected static MessageRootProperties ExtractMessageRootProperties(JsonElement payload)
 	{
 		var objectKey = payload.GetProperty(Consts.MessageObjectKeyPropertyName).GetString();
 		var objectType = payload.GetProperty(Consts.MessageObjectTypePropertyName).GetString();
@@ -59,7 +59,7 @@ public abstract class VersionedSchemaBaseService(ILockService lockService)
 		ArgumentException.ThrowIfNullOrWhiteSpace(objectType);
 		ArgumentException.ThrowIfNullOrWhiteSpace(dataVersion);
 
-		return new RootMessageProperties
+		return new MessageRootProperties
 		{
 			objectKey = objectKey,
 			objectType = objectType,


### PR DESCRIPTION
[AB#40964](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/40964)

- Added new constants `MessageEventTypePropertyName` and `DeltaEventType` to the `Consts` class.
- Updated `SapAct.csproj` to use wildcard versioning for `Azure.Identity`.
- Refactored `ADXService`, `LogAnalyticsService`, and `SQLService` to use `RootMessageProperties` and added early return for `DeltaEventType`.
- Modified `VersionedSchemaBaseService` to return `RootMessageProperties` from `ExtractKeyMessageProperties`.
- Introduced `RootMessageProperties` record in `SapAct.Models` namespace to encapsulate key message properties.