### PR TITLE
Refactor SQLService and add schema update checks

### DIFF
--- a/src/SapAct/Extensions/EnumExtensions.cs
+++ b/src/SapAct/Extensions/EnumExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace SapAct.Extensions;
+
+public static class EnumExtensions
+{
+	public static bool IsUpdateRequired(this SchemaCheckResultState schemaCheckResultState)
+	{
+		return schemaCheckResultState == SchemaCheckResultState.Older || schemaCheckResultState == SchemaCheckResultState.Unknown;
+	}
+}


### PR DESCRIPTION
Introduce IsUpdateRequired method in EnumExtensions to determine schema update necessity. Modify SQLService to use this new method.
Add dryRun parameter to UpsertSQLStructuresAsync and UpsertSQLTableAsync. Update EmitTableInsertStatement to use parameterized queries. Make CheckTableExistsAsync, EmitTableCreateCommand, EmitTableUpdateCommand, and MergeTableDescriptors static. Improve code readability and maintainability in SQLService.

[AB#41934](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/41934)