### PR TITLE
Add error handling for CreateSubscriptionAsync method

### DIFF
--- a/src/SapAct/Workers/SapActBaseWorker.cs
+++ b/src/SapAct/Workers/SapActBaseWorker.cs
@@ -36,7 +36,19 @@ public abstract class SapActBaseWorker<T>(
 
 		if (!await managementClient.SubscriptionExistsAsync(topicName, subscriptionName, cancellationToken))
         {
-            await managementClient.CreateSubscriptionAsync(topicName, subscriptionName, cancellationToken);
+			try
+			{
+				await managementClient.CreateSubscriptionAsync(topicName, subscriptionName, cancellationToken);
+			}
+			catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+			{
+				//do nothing, subscription already exists
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "Error creating subscription");
+				throw;
+			}
 		}
     }
 


### PR DESCRIPTION
Introduce a try-catch block around managementClient.CreateSubscriptionAsync to handle specific exceptions. Ignore ServiceBusException with reason MessagingEntityAlreadyExists, and log and rethrow any other exceptions to avoid suppressing unexpected errors.