### PR TITLE
Case insensitive property name/column name logic

### DIFF
--- a/src/SapAct/Models/SQLTableDescriptor.cs
+++ b/src/SapAct/Models/SQLTableDescriptor.cs
@@ -7,16 +7,16 @@ public record SQLTableDescriptor
 	public required int Depth { get; set; }
 	public List<SQLColumnDescriptor> Columns { get; init; } = [];
 	public List<SQLTableDescriptor> ChildTables { get; init; } = [];
-	public SQLTableDescriptor GetChildTableDescriptor(string childTableName)
+	public SQLTableDescriptor? GetChildTableDescriptor(string childTableName)
 	{
-		return ChildTables.First(x => x.TableName == childTableName);
+		return ChildTables.FirstOrDefault(x => x.TableName == childTableName);
 	}
 
 	public bool IsEmpty => Columns.Count == 0 && ChildTables.Count == 0;
 
-	public SQLColumnDescriptor FindColumnCaseInsensitive(string columnName)
+	public SQLColumnDescriptor? GetIgnoreCaseColumnDescriptor(string columnName)
 	{
-		return Columns.First(x => x.ColumnName.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+		return Columns.FirstOrDefault(x => x.ColumnName.Equals(columnName, StringComparison.OrdinalIgnoreCase));
 	}
 }
 

--- a/src/SapAct/Models/SQLTableDescriptor.cs
+++ b/src/SapAct/Models/SQLTableDescriptor.cs
@@ -13,10 +13,16 @@ public record SQLTableDescriptor
 	}
 
 	public bool IsEmpty => Columns.Count == 0 && ChildTables.Count == 0;
+
+	public SQLColumnDescriptor FindColumnCaseInsensitive(string columnName)
+	{
+		return Columns.First(x => x.ColumnName.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+	}
 }
 
 public record SQLColumnDescriptor
 {
-	public required string ColumnName { get; init; }
+	public required string ColumnName { get; set; }
 	public required string SQLDataType { get; init; }
+	public bool IsSchemaColumn { get; set; }
 }

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -300,7 +300,7 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 			columnToRename.ColumnName = columns.Where(x => x.Equals(diffCasingColumn, StringComparison.OrdinalIgnoreCase)).First();
 		}
 
-		if (addedColumns.Count() == 0)
+		if (!addedColumns.Any())
 			return string.Empty;
 
 		

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -418,7 +418,7 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 
 			if (depth > 0)
 			{
-				//add PK and FK as implied columns
+				//add PK and FK as explicit columns
 				schemaDescriptor.Columns.Add(new SQLColumnDescriptor() { ColumnName = "PK", SQLDataType = "NVARCHAR(255)", IsSchemaColumn = true });
 				schemaDescriptor.Columns.Add(new SQLColumnDescriptor() { ColumnName = "FK", SQLDataType = "NVARCHAR(255)", IsSchemaColumn = true });
 			}

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -283,7 +283,7 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 		var schemaDescriptorColumnNames = schemaDescriptor.Columns.Select(x => x.ColumnName).ToList();
 
 		List<string> addedColumns = schemaDescriptorColumnNames
-			.Except(columns, StringComparer.OrdinalIgnoreCase).ToList(); //find added columns - only additive schema changes are applied - ingnore casing
+			.Except(columns, StringComparer.OrdinalIgnoreCase).ToList(); //find added columns - only additive schema changes are applied - ignore casing
 
 		//for updates, we must consider casing changes so best to update schema object to use previously seen casing
 		var differentCasingColumns = schemaDescriptorColumnNames

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -26,6 +26,8 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 					var schemaCheck = await CheckObjectTypeSchemaAsync(messageProperties.objectType, messageProperties.dataVersion, TargetStorageEnum.SQL);
 						
 					var schemaDescriptor = await GenerateSchemaDescriptorAsync(messageProperties.objectType, payload);
+					///dry run to check if schema update is necessary as certain (sub)structures may only be populated for specific payload instances
+					///so we can only build up a schema when these are set - data version property refers to logical schema but not it used in its entirety
 					var dryRunSchemaCheck = !schemaCheck.IsUpdateRequired() && await UpsertSQLStructuresAsync(schemaDescriptor, cancellationToken, dryRun: true);
 
 					if (schemaCheck.IsUpdateRequired() || dryRunSchemaCheck)

--- a/src/SapAct/Services/SQLService.cs
+++ b/src/SapAct/Services/SQLService.cs
@@ -282,10 +282,10 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 	{
 		StringBuilder tableUpdateSB = new();
 
-		var schemaDescriptorColumnNames = schemaDescriptor.Columns.Select(x => x.ColumnName).ToList();
+		var schemaDescriptorColumnNames = schemaDescriptor.Columns.Select(x => x.ColumnName);
 
-		List<string> addedColumns = schemaDescriptorColumnNames
-			.Except(columns, StringComparer.OrdinalIgnoreCase).ToList(); //find added columns - only additive schema changes are applied - ignore casing
+		var addedColumns = schemaDescriptorColumnNames
+			.Except(columns, StringComparer.OrdinalIgnoreCase); //find added columns - only additive schema changes are applied - ignore casing
 
 		//for updates, we must consider casing changes so best to update schema object to use previously seen casing
 		var differentCasingColumns = schemaDescriptorColumnNames
@@ -298,7 +298,7 @@ public class SQLService(IServiceProvider serviceProvider, ILockService lockServi
 			columnToRename.ColumnName = columns.Where(x => x.Equals(diffCasingColumn, StringComparison.OrdinalIgnoreCase)).First();
 		}
 
-		if (addedColumns.Count == 0)
+		if (addedColumns.Count() == 0)
 			return string.Empty;
 
 		


### PR DESCRIPTION
[AB#43606](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/43606)


Added FindColumnCaseInsensitive method to SQLTableDescriptor for case-insensitive column lookups. Changed ColumnName property in SQLColumnDescriptor to be mutable and added IsSchemaColumn property. Updated SQLService to use the new method for adding parameters to SQL commands. Refactored PK and FK handling in SQLService for clarity and correctness. Modified EmitTableUpdateCommand for case-insensitive comparisons and schema object updates. Simplified GenerateSchemaDescriptorInner by removing depth parameter and including implied columns based on depth.