### PR TITLE
AB#93251: Update Azure secrets to new Entra naming convention

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,7 @@ name: CD for SapAct
 
 on:
   workflow_dispatch:
-        
+
   push:
     branches:
       - main

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,7 +19,7 @@ jobs:
   SapAct_CD:
     uses: ./.github/workflows/shared-app-cd-workflow.yaml
     secrets:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.ENTRA_PROD_WORKFORCE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_PLATFORM_SUBSCRIPTION_ID: ${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}
       AZURE_DEV_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEV_SUBSCRIPTION_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
   SapAct_CI:
     uses: ./.github/workflows/shared-app-ci-workflow.yaml
     secrets:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.ENTRA_PROD_WORKFORCE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEV_SUBSCRIPTION_ID }}
       ACTIONS_AUTH_APP_ID: ${{ secrets.ACTIONS_AUTH_APP_ID }}


### PR DESCRIPTION
Updates AZURE_TENANT_ID to ENTRA_PROD_WORKFORCE_TENANT_ID in CD workflows per [AB#93251](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/93251)