### PR TITLE
feat: add revisionHistoryLimit: 2 to deployment

### DIFF
--- a/charts/SapAct/sapact/templates/deployment.yaml
+++ b/charts/SapAct/sapact/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     service: sapact-service
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       service: sapact-service

--- a/charts/SapAct/sapact/values.yaml
+++ b/charts/SapAct/sapact/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+revisionHistoryLimit: 2
 AKSClusterSAName: TBD
 ACRName: TBD
 configKeyVault: TBD


### PR DESCRIPTION
Adds revisionHistoryLimit: 2 to the sapact deployment spec.